### PR TITLE
Fix workspace exit

### DIFF
--- a/backend/src/grapycal/app.py
+++ b/backend/src/grapycal/app.py
@@ -37,7 +37,7 @@ class GrapycalApp:
         #TODO: Websocket multiplexing
 
         # Here simply start one workspace in background
-        workspace = subprocess.Popen([sys.executable,'-m', 'grapycal.core.workspace', '--port', str(self._config['port']), '--host', self._config['host']])
+        workspace = subprocess.Popen([sys.executable,'-m', 'grapycal.core.workspace', '--port', str(self._config['port']), '--host', self._config['host']], start_new_session=True)
         while True:
             break_flag = False
             try:
@@ -55,7 +55,6 @@ class GrapycalApp:
                 break
 
         print('Stopping workspaces...')
-        # IDK why workspace can't catch this signal before being killed
         workspace.send_signal(signal.SIGTERM)
         workspace.wait()
         self.clean_unused_fetched_extensions()

--- a/backend/src/grapycal/core/background_runner.py
+++ b/backend/src/grapycal/core/background_runner.py
@@ -31,6 +31,7 @@ class BackgroundRunner:
 
     def exit(self):
         self._exit_flag = True
+        self.interrupt()
 
     @contextmanager
     def no_interrupt(self):

--- a/backend/src/grapycal/core/workspace.py
+++ b/backend/src/grapycal/core/workspace.py
@@ -72,7 +72,7 @@ class Workspace:
         Register all built-in node types
         '''
 
-        signal.signal(signal.SIGTERM, lambda sig, frame: self.exit()) #? Why this does not work?
+        signal.signal(signal.SIGTERM, lambda sig, frame: self.exit())
 
         if file_exists(self.path):
             self.load_workspace(self.path)


### PR DESCRIPTION
Originally, `BackgroundRunner.run` cannot exit stably, sometimes you need 3rd Ctrl-C to exit and error message will pop up.
The problem is that Ctrl-C (SIGINT) will be sent to the whole process group, so our workspace process will also receive that.

When 2nd SIGINT is sent, 2 things happened:
1. `GrapycalApp.run`: [`KeyboardInterrupt` on line 51](https://github.com/eri24816/Grapycal/blob/59acadc05e1bda245b8778fb658e1d52a06e2629/backend/src/grapycal/app.py#L50) is caught, `break_flag` is set to true and thus SIGTERM is sent to workspace by [line 59](https://github.com/eri24816/Grapycal/blob/59acadc05e1bda245b8778fb658e1d52a06e2629/backend/src/grapycal/app.py#L59). With the signal handler set in `Workspace.run`, `BackgroundRunner.exit` is called and `BackgroundRunner._exit_flag` is set to True.
2. `BackgroundRunner.run`: The `KeyboardInterrupt` is also received here, the outer while loop in `run` starts from the beginning, checks `BackgroundRunner._exit_flag` to determine if it should break.

Notice that to exit correctly, 1 must finish before 2. However, we can't control the order since it's in 2 different process.


In the fixed version, `GrapycalApp.run` uses `subprocess.Popen(..., start_new_session=True)` to put workspace into another process group, so workspace won't receive SIGINT that's meant to be sent to `GrapycalApp`. To put it simply, it makes the 2nd SIGINT only trigger the 1st behavior we listed.
Also, in `BackgroundRunner.exit`, ***after*** `_exit_flag` is set, we call `BackgroundRunner.interrupt` to manually interrupt itself. The outer while will then start from the beginning, with the fact that `_exit_flag` is, surely, set to `True`.